### PR TITLE
Release for v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [v0.1.0](https://github.com/handlename/task-result/compare/v0.0.3...v0.1.0) - 2024-07-09
+- Read file as source by @handlename in https://github.com/handlename/task-result/pull/8
+
 ## [v0.0.3](https://github.com/handlename/task-result/compare/v0.0.2...v0.0.3) - 2024-07-05
 - Release with GH_PAT by @handlename in https://github.com/handlename/task-result/pull/6
 

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package taskr
 
-const Version = "0.0.3"
+const Version = "0.1.0"


### PR DESCRIPTION
This pull request is for the next release as v0.1.0 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.1.0 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.0.3" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* Read file as source by @handlename in https://github.com/handlename/task-result/pull/8


**Full Changelog**: https://github.com/handlename/task-result/compare/v0.0.3...v0.1.0