### PR TITLE
Fix print version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,8 @@
 # Go workspace file
 go.work
 
+# make build
+cmd/taskr/taskr
+
 # GoReleaser dist dir
 dist/

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,5 @@
 test:
 	go test -v ./...
+
+build:
+	go build -o cmd/taskr/taskr ./cmd/taskr

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"os/signal"
@@ -28,7 +29,7 @@ func Run() ExitCode {
 	taskr.InitLogger(flags.LogLevel)
 
 	if flags.Version {
-		log.Info().Msgf("task-result v%s", taskr.Version)
+		fmt.Printf("%s v%s", os.Args[0], taskr.Version)
 		return ExitCodeOK
 	}
 

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -39,6 +39,10 @@ func parseFlags(appname string, args []string) (*Flags, error) {
 		return nil, failure.Wrap(err, failure.Message("failed to parse flags"))
 	}
 
+	if flags.Version {
+		return flags, nil
+	}
+
 	rest := fs.Args()
 	if len(rest) != 1 {
 		return nil, failure.New(errorcode.ErrInvalidArgument, failure.Message(`only one source path is required`))


### PR DESCRIPTION
before

```console
$ go run cmd/taskr/main.go -version
{"level":"error","error":"cli.parseFlags[InvalidArgument](only one source path is required)","time":"2024-07-09T22:14:28+09:00","message":"failed to parse flags"}
exit status 1
```

after

```console
$ go run cmd/taskr/main.go -version
/var/folders/s1/dn__ynxx1xjcs6wvyx161kfr0000gp/T/go-build146939724/b001/exe/main v0.1.0
```

```console
$ make build
$ ./cmd/taskr/taskr -version
./cmd/taskr/taskr v0.1.0
```
