### PR TITLE
Release for v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [v0.2.0](https://github.com/handlename/task-result/compare/v0.1.1...v0.2.0) - 2025-05-02
+- chore(deps): bump github.com/stretchr/testify from 1.9.0 to 1.10.0 by @dependabot in https://github.com/handlename/task-result/pull/12
+- chore(deps): bump github.com/rs/zerolog from 1.33.0 to 1.34.0 by @dependabot in https://github.com/handlename/task-result/pull/14
+
 ## [v0.1.1](https://github.com/handlename/task-result/compare/v0.1.0...v0.1.1) - 2024-07-09
 - Fix print version by @handlename in https://github.com/handlename/task-result/pull/10
 

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package taskr
 
-const Version = "0.1.1"
+const Version = "0.2.0"


### PR DESCRIPTION
This pull request is for the next release as v0.2.0 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.2.0 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.1.1" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* chore(deps): bump github.com/stretchr/testify from 1.9.0 to 1.10.0 by @dependabot in https://github.com/handlename/task-result/pull/12
* chore(deps): bump github.com/rs/zerolog from 1.33.0 to 1.34.0 by @dependabot in https://github.com/handlename/task-result/pull/14

## New Contributors
* @dependabot made their first contribution in https://github.com/handlename/task-result/pull/12

**Full Changelog**: https://github.com/handlename/task-result/compare/v0.1.1...v0.2.0